### PR TITLE
Avoid issue of CRS vs crs in class checks

### DIFF
--- a/R/SegSpatial-class.R
+++ b/R/SegSpatial-class.R
@@ -16,7 +16,7 @@ setValidity(Class = "SegSpatial",
             })
 
 SegSpatial <- function(d, r, h, p, coords, data, env, 
-                       proj4string = CRS(as.character(NA))) {
+                       proj4string = st_crs(as.character(NA))) {
   new("SegSpatial", d = d, r = r, h = h, p = p, coords = coords, data = data, 
       env = env, proj4string = proj4string)
 }

--- a/R/SegSpatial-methods.R
+++ b/R/SegSpatial-methods.R
@@ -10,7 +10,7 @@
 setAs("SegSpatial", "SpatialPoints", 
       function(from) {
         validObject(from)
-        SpatialPoints(coords = from@coords, proj4string = from@proj4string)
+        SpatialPoints(coords = from@coords, proj4string = CRS(from@proj4string$input))
       })
 
 setAs("SegSpatial", "SpatialPointsDataFrame", 
@@ -18,7 +18,7 @@ setAs("SegSpatial", "SpatialPointsDataFrame",
         validObject(from)
         SpatialPointsDataFrame(coords = from@coords, 
                                data = data.frame(from@data),
-                               proj4string = from@proj4string)
+                               proj4string = CRS(from@proj4string$input))
       })
 
 setAs("SegSpatial", "SpatialPixelsDataFrame", 
@@ -26,7 +26,7 @@ setAs("SegSpatial", "SpatialPixelsDataFrame",
         validObject(from)
         SpatialPixelsDataFrame(points = from@coords, 
                                data = data.frame(from@data),
-                               proj4string = from@proj4string)
+                               proj4string = CRS(from@proj4string$input))
       })
 
 #setAs("SegSpatial", "SegLocal", 

--- a/R/localenv.R
+++ b/R/localenv.R
@@ -39,5 +39,5 @@ localenv <- function(x, data, power = 2, useExp = TRUE, scale = FALSE,
   
   env <- localenv.get(sprel, data, power, useExp, scale, maxdist, tol)
   
-  SegLocal(coords, data, env, CRS(proj4string))
+  SegLocal(coords, data, env, st_crs(proj4string))
 }

--- a/R/spseg.R
+++ b/R/spseg.R
@@ -54,7 +54,7 @@ spseg <- function(x, data, method = "all", smoothing = "none",
   # STEP 3 Calculate the population composition of each local environment
   # ----------------------------------------------------------------------------
   env <- localenv(coords, data, ...)
-  env <- update(env, proj4string = CRS(proj4string))
+  env <- update(env, proj4string = st_crs(proj4string))
   
   # ----------------------------------------------------------------------------
   # STEP 4 Compute the segregation indices


### PR DESCRIPTION
Minor switches from `CRS()` to `st_crs()`. This avoids the following error and by passing through a `crs` class.

Error message in R 4.5.1 was:
> invalid class “SegLocal” object: invalid object for slot "proj4string" in class "SegLocal": got class "CRS", should be or extend class "crs"